### PR TITLE
Plain icon compatible with PopOS

### DIFF
--- a/poweroff-button-on-topbar@darknico.com/extension.js
+++ b/poweroff-button-on-topbar@darknico.com/extension.js
@@ -19,7 +19,7 @@ function init() {
 function enable() {
 
     icon = new St.Icon({
-        icon_name: 'system-shutdown',
+        icon_name: 'system-shutdown-symbolic',
         style_class: 'system-status-icon'
     });
 


### PR DESCRIPTION
### Description of the Change

I encountered an issue with the extension icon on Pop!_OS 22.04 LTS, where it was displayed incorrectly. The screenshot below shows the problem:

![Screenshot from 2024-07-24 00-58-21](https://github.com/user-attachments/assets/6541d697-dba3-437d-8147-38a2f7aabb91)

After my modification, the extension icon displays correctly, as shown in the following screenshot:

![Screenshot from 2024-07-24 00-53-33](https://github.com/user-attachments/assets/46966663-21ea-4a4d-8f83-a835e44a90d0)

### Changes Made

- Changed the icon to 'system-shutdown-symbolic'

### Tests Performed

- Verified on Pop!_OS 22.04 LTS

### Request for Testing

Can you please test these changes on Ubuntu 22.04 to ensure the icon is displayed correctly?
